### PR TITLE
Use prefix iterators for Get/Has()

### DIFF
--- a/datastore.go
+++ b/datastore.go
@@ -47,6 +47,9 @@ func NewDatastore(path string, opts *pebble.Options) (*Datastore, error) {
 	// negative results, and those are currently very expensive and
 	// trigger a fair amount of reads. See
 	// https://github.com/cockroachdb/pebble/issues/2369#issuecomment-1450997680
+	if opts.Comparer.Split != nil {
+		logger.Warn("Comparer Split's function is not nil. To ensure that go-ds-pebble behaves correctly, it will be overwritten. See https://github.com/ipfs/go-ds-pebble/pull/26")
+	}
 	opts.Comparer.Split = defaultSplit
 
 	db, err := pebble.Open(path, opts)

--- a/datastore_test.go
+++ b/datastore_test.go
@@ -1,9 +1,12 @@
 package pebbleds
 
 import (
+	"bytes"
+	"context"
 	"os"
 	"testing"
 
+	"github.com/ipfs/go-datastore"
 	dstest "github.com/ipfs/go-datastore/test"
 )
 
@@ -30,5 +33,44 @@ func newDatastore(t *testing.T) (*Datastore, func()) {
 	return d, func() {
 		_ = d.Close()
 		_ = os.RemoveAll(path)
+	}
+}
+
+func TestGet(t *testing.T) {
+	ds, cleanup := newDatastore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	k := datastore.NewKey("a")
+	v := []byte("val")
+	err := ds.Put(ctx, k, v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ds.Put(ctx, datastore.NewKey("aa"), v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ds.Put(ctx, datastore.NewKey("ac"), v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	has, err := ds.Has(ctx, datastore.NewKey("ab"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if has {
+		t.Fatal("should not have key")
+	}
+
+	val, err := ds.Get(ctx, k)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(v, val) {
+		t.Error("not equal", string(val))
 	}
 }

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.2.2"
+  "version": "v0.2.3"
 }


### PR DESCRIPTION
Pebble's Get implementation uses regular iterators under the hood, which result in reading data out of sstables even when the key that we are looking for does not exist (it will read the next key AND value).

This makes Has() and Get() calls very expensive for non existent keys (equivalent to reading an existing one).

Per Pebble devs recommendation, we must use an iterator and SeekPrefixGE() to make use of bloom filters, and bloom filters are built according to the Split function in the Comparer, which is unset by default.

This PR forces setting the Split function in the options and uses SeekPrefixGE() for Has()/Get(), which should make use of bloom filters.

The downside is that we do not allow custom Split functions, but we were not taking advantage of them anyways. The second downside is that compactions will call Split() for every item (to prime the bloom filters), so write performance might be a bit worse.

Has() is still an expensive operation for existing keys, since the values are read, but this cannot be really fixed.

For more details: https://github.com/cockroachdb/pebble/issues/2369