### PR TITLE
Add WithPebbleDB configuration option to Datastore implementation

### DIFF
--- a/datastore_test.go
+++ b/datastore_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/pebble"
 	"github.com/ipfs/go-datastore"
 	dstest "github.com/ipfs/go-datastore/test"
 )
@@ -36,10 +37,45 @@ func newDatastore(t *testing.T) (*Datastore, func()) {
 	}
 }
 
+func newDatastoreWithPebbleDB(t *testing.T) (*Datastore, func()) {
+	t.Helper()
+
+	path, err := os.MkdirTemp(os.TempDir(), "testing_pebble_with_db")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	db, err := pebble.Open(path, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	d, err := NewDatastore(path, nil, WithPebbleDB(db))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return d, func() {
+		_ = d.Close()
+		_ = os.RemoveAll(path)
+	}
+}
+
 func TestGet(t *testing.T) {
 	ds, cleanup := newDatastore(t)
 	defer cleanup()
 
+	testDatastore(t, ds)
+}
+
+func TestGetWithPebbleDB(t *testing.T) {
+	ds, cleanup := newDatastoreWithPebbleDB(t)
+	defer cleanup()
+
+	testDatastore(t, ds)
+}
+
+func testDatastore(t *testing.T, ds *Datastore) {
 	ctx := context.Background()
 	k := datastore.NewKey("a")
 	v := []byte("val")


### PR DESCRIPTION

## Context 
This pull request introduces the `WithPebbleDB` option and related enhancements to the `Datastore` implementation.

The `WithPebbleDB` allows users to specify custom Pebble DB, providing greater flexibility in configuring the database to meet specific performance and resource requirements. This addition improves the adaptability for various use cases. 

This pull request also includes tests to validate the new configuration options, ensuring they work as intended and do not introduce regressions.