### PR TITLE
feat: simplify pebble datastore creation with single set of options

### DIFF
--- a/datastore_test.go
+++ b/datastore_test.go
@@ -26,7 +26,7 @@ func newDatastore(t *testing.T) (*Datastore, func()) {
 		t.Fatal(err)
 	}
 
-	d, err := NewDatastore(path, nil)
+	d, err := NewDatastore(path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,7 +50,7 @@ func newDatastoreWithPebbleDB(t *testing.T) (*Datastore, func()) {
 		t.Fatal(err)
 	}
 
-	d, err := NewDatastore(path, nil, WithPebbleDB(db))
+	d, err := NewDatastore(path, WithPebbleDB(db))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/option.go
+++ b/option.go
@@ -1,0 +1,48 @@
+package pebbleds
+
+import (
+	"github.com/cockroachdb/pebble"
+)
+
+type config struct {
+	cacheSize  int64
+	db         *pebble.DB
+	pebbleOpts *pebble.Options
+}
+
+type Option func(*config)
+
+func getOpts(options []Option) config {
+	var cfg config
+	for _, opt := range options {
+		if opt == nil {
+			continue
+		}
+		opt(&cfg)
+	}
+	return cfg
+}
+
+// WithCacheSize configures the size of pebble's shared block cache. A value of
+// 0 (the default) uses the default cache size.
+func WithCacheSize(size int64) Option {
+	return func(c *config) {
+		c.cacheSize = size
+	}
+}
+
+// WithPebbleDB is used to configure the Datastore with a custom DB.
+func WithPebbleDB(db *pebble.DB) Option {
+	return func(c *config) {
+		c.db = db
+	}
+}
+
+// WithPebbleOpts sets any/all configurable values for pebble. If not set, the
+// default configuration values are used. Any unspecified value in opts is
+// replaced by the default value.
+func WithPebbleOpts(opts *pebble.Options) Option {
+	return func(c *config) {
+		c.pebbleOpts = opts
+	}
+}


### PR DESCRIPTION
Use a single set of options when creating the Pebble Datastore. One of the options allows passing a struct containing  Pebble options. It is no longer necessary to pass `nil` when using the default configuration.

Make it easier to handle creation/teardown of a custom-sized Pebble shared block cache. Only the cache size needs to be specified as a creation option if using other the default size. Instead of requiring the caller to pass in a cache instance, and manage its lifetime, a `WithCacheSize` option can pass the size and let the pebble Datastore manage the cache lifetime. Passing in a cache can optionally still be done.