### PR TITLE
fix panic when batch is reused after commit

### DIFF
--- a/datastore.go
+++ b/datastore.go
@@ -425,5 +425,6 @@ func (b *Batch) Delete(ctx context.Context, key ds.Key) error {
 }
 
 func (b *Batch) Commit(ctx context.Context) error {
+	defer b.batch.Reset() // make batch reusable
 	return b.batch.Commit(pebble.NoSync)
 }

--- a/datastore_test.go
+++ b/datastore_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base32"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"testing"
 
@@ -126,11 +126,13 @@ func TestBatch(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	var seed [32]byte
+	cc8 := rand.NewChaCha8(seed)
 	var blocks [][]byte
 	var keys []datastore.Key
 	for i := 0; i < 20; i++ {
 		blk := make([]byte, 256*1024)
-		rand.Read(blk)
+		cc8.Read(blk)
 		blocks = append(blocks, blk)
 
 		key := datastore.NewKey(base32.StdEncoding.EncodeToString(blk[:8]))
@@ -164,7 +166,7 @@ func TestBatch(t *testing.T) {
 
 	for i := 0; i < 20; i++ {
 		blk := make([]byte, 256*1024)
-		rand.Read(blk)
+		cc8.Read(blk)
 		blocks = append(blocks, blk)
 
 		key := datastore.NewKey(base32.StdEncoding.EncodeToString(blk[:8]))


### PR DESCRIPTION
If a batch was reused after calling Commit, this would cause a panic:
```
panic: pebble: batch already committing
```

It is necessary to reset the internal pebble batch before it can be reused.