### PR TITLE
Make pebble write options configurable

### DIFF
--- a/datastore_test.go
+++ b/datastore_test.go
@@ -193,5 +193,4 @@ func TestBatch(t *testing.T) {
 			t.Fatal("blocks not correct!")
 		}
 	}
-
 }

--- a/option.go
+++ b/option.go
@@ -5,9 +5,10 @@ import (
 )
 
 type config struct {
-	cacheSize  int64
-	db         *pebble.DB
-	pebbleOpts *pebble.Options
+	cacheSize          int64
+	db                 *pebble.DB
+	pebbleOpts         *pebble.Options
+	pebbleWriteOptions *pebble.WriteOptions
 }
 
 type Option func(*config)
@@ -44,5 +45,13 @@ func WithPebbleDB(db *pebble.DB) Option {
 func WithPebbleOpts(opts *pebble.Options) Option {
 	return func(c *config) {
 		c.pebbleOpts = opts
+	}
+}
+
+// WithPebbleWriteOptions configures the write options for the datastore. If
+// not set, pebble.NoSync is used.
+func WithPebbleWriteOptions(opts *pebble.WriteOptions) Option {
+	return func(c *config) {
+		c.pebbleWriteOptions = opts
 	}
 }


### PR DESCRIPTION
The current implementation uses `pebble.NoSync` for all writes. This means that data could be lost if the node crashed before before pebble performed the sync operation. It's probably a sensible default for most usecases within ipfs. In our usecase, the producers must have a guarantee that data exists in the db after the commit returns successfully.

This PR adds and option to make the write options configurable.