### PR TITLE
Do not allow batch to be reused after commit

### DIFF
--- a/datastore_test.go
+++ b/datastore_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base32"
+	"errors"
 	"math/rand/v2"
 	"os"
 	"testing"
@@ -158,8 +159,13 @@ func TestBatch(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// second commit should do nothing, but should not cause an error
+	// second commit should return a ErrBatchCommitted error.
 	err = batch.Commit(ctx)
+	if !errors.Is(err, ErrBatchCommitted) {
+		t.Fatalf("expected error: %s, got %v", ErrBatchCommitted, err)
+	}
+
+	batch, err = ds.Batch(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
By explicitly not allowing the Batch to be reused, the Batch resources can be recycled, after Commit is called, for use in a new Batch.

In general, a Batch should not be reuesd for this or any other datastore becuase it is not guaranteed to be safely reusable for all datastores. Therefore, making this Batch explicitly not reusable allows better resource management as well as returning a clear error when the Batch is mistakenly reused.